### PR TITLE
Add memory to task runtime

### DIFF
--- a/test/data/config/longtask/workflow_config_minutes_longtask_IO.json
+++ b/test/data/config/longtask/workflow_config_minutes_longtask_IO.json
@@ -1,0 +1,143 @@
+{
+  "header": {
+    "time": false
+  },
+  "graph": {
+    "directed": true,
+    "multigraph": false,
+    "calc": true,
+    "graph": {
+      "node_default": {},
+      "edge_default": {}
+    },
+    "nodes": [
+      {
+        "comp": 0,
+        "id": 0,
+        "task_data": 7140000
+      },
+      {
+        "comp": 0,
+        "id": 1,
+        "task_data": 5520000
+      },
+      {
+        "comp": 0,
+        "id": 2,
+        "task_data": 5700000
+      },
+      {
+        "comp": 0,
+        "id": 3,
+        "task_data": 6540000
+      },
+      {
+        "comp": 0,
+        "id": 4,
+        "task_data": 6420000
+      },
+      {
+        "comp": 0,
+        "id": 5,
+        "task_data": 10140000
+      },
+      {
+        "comp": 0,
+        "id": 6,
+        "task_data": 6600000
+      },
+      {
+        "comp": 0,
+        "id": 7,
+        "task_data": 8820000
+      },
+      {
+        "comp": 0,
+        "id": 8,
+        "task_data": 8760000
+      },
+      {
+        "comp": 0,
+        "id": 9,
+        "task_data": 6060000
+      }
+    ],
+    "links": [
+      {
+        "transfer_data": 1080,
+        "source": 0,
+        "target": 1
+      },
+      {
+        "transfer_data": 720,
+        "source": 0,
+        "target": 2
+      },
+      {
+        "transfer_data": 540,
+        "source": 0,
+        "target": 3
+      },
+      {
+        "transfer_data": 660,
+        "source": 0,
+        "target": 4
+      },
+      {
+        "transfer_data": 840,
+        "source": 0,
+        "target": 5
+      },
+      {
+        "transfer_data": 960,
+        "source": 1,
+        "target": 8
+      },
+      {
+        "transfer_data": 1140,
+        "source": 1,
+        "target": 7
+      },
+      {
+        "transfer_data": 1380,
+        "source": 2,
+        "target": 6
+      },
+      {
+        "transfer_data": 1380,
+        "source": 3,
+        "target": 8
+      },
+      {
+        "transfer_data": 1620,
+        "source": 3,
+        "target": 7
+      },
+      {
+        "transfer_data": 780,
+        "source": 4,
+        "target": 8
+      },
+      {
+        "transfer_data": 900,
+        "source": 5,
+        "target": 7
+      },
+      {
+        "transfer_data": 1020,
+        "source": 6,
+        "target": 9
+      },
+      {
+        "transfer_data": 660,
+        "source": 7,
+        "target": 9
+      },
+      {
+        "transfer_data": 780,
+        "source": 8,
+        "target": 9
+      }
+    ]
+  }
+}

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -216,8 +216,8 @@ class TestSchedulerDynamicPlanAllocation(unittest.TestCase):
         self.env.process(self.scheduler.allocate_tasks(curr_obs))
         self.env.run(1)
         self.assertListEqual(
-            l,
-            [a.task.tid for a in curr_obs.plan.exec_order]
+            exec_ord,
+            curr_obs.plan.exec_order
         )
         self.buffer.cold[0].observations['stored'].append(curr_obs)
         self.env.run(until=99)
@@ -267,8 +267,8 @@ class TestSchedulerDynamicPlanWithIO(unittest.TestCase):
         self.env.process(self.scheduler.allocate_tasks(curr_obs))
         self.env.run(1)
         self.assertListEqual(
-            l,
-            [a.task.tid for a in curr_obs.plan.exec_order]
+            exec_ord,
+            curr_obs.plan.exec_order
         )
         self.buffer.cold[0].observations['stored'].append(curr_obs)
         self.env.run(until=99)

--- a/test/test_scheduling.py
+++ b/test/test_scheduling.py
@@ -107,7 +107,7 @@ class TestBatchSchedulerAllocation(unittest.TestCase):
         # Replicate the Scheduler allocate_task() methods
         existing_schedule = {}
         task_pool = set()
-        existing_schedule, status = self.algorithm.run(
+        existing_schedule, status, task_pool = self.algorithm.run(
             self.cluster, self.env.now, obs.plan, existing_schedule,task_pool
         )
         self.assertTrue(obs.plan.tasks[0] in existing_schedule)

--- a/topsim/core/cluster.py
+++ b/topsim/core/cluster.py
@@ -394,7 +394,7 @@ class Cluster:
         if size > tmp > 0:
             size = tmp
         for m in range(0, size):
-            self._add_idle_resource(name, available_resources[0])
+            self._add_idle_resource(name, available_resources[m])
 
         self.num_provisioned_obs += 1
         return True
@@ -449,7 +449,8 @@ class Cluster:
             self._clusters[c]['resources']['available'].append(m)
 
     def get_available_resources(self, c='default'):
-        return self._clusters[c]['resources']['available']
+        # TODO Figure out why this breaks in one but not the other
+        return [x for x in self._clusters[c]['resources']['available']]
 
     def is_observation_provisioned(self, observation, c='default'):
         return observation in self._clusters[c]['resources']['idle']

--- a/topsim/core/scheduler.py
+++ b/topsim/core/scheduler.py
@@ -293,7 +293,7 @@ class Scheduler:
         self._add_event(observation, "allocation", "started")
         while True:
             current_plan.tasks = self._update_current_plan(current_plan)
-            current_plan, schedule, finished = self._generate_current_schedule(
+            current_plan, schedule, task_pool, finished = self._generate_current_schedule(
                 observation, current_plan, schedule, task_pool)
             # prev_tasks = _curr_tasks
             # _curr_tasks = len(current_plan.tasks)
@@ -340,7 +340,7 @@ class Scheduler:
         finished = False
         nm = f'{observation.name}-algtime'
         self.algtime[nm] = time.time()
-        schedule, status = self.algorithm.run(cluster=self.cluster,
+        schedule, status, task_pool = self.algorithm.run(cluster=self.cluster,
             clock=self.env.now, workflow_plan=current_plan,
             existing_schedule=schedule, task_pool=task_pool)
         self.algtime[nm] = (time.time() - self.algtime[nm])
@@ -362,7 +362,7 @@ class Scheduler:
                 finished = True
                 LOGGER.info(f"{observation.name} finished @ {self.env.now}")
 
-        return current_plan, schedule, finished
+        return current_plan, schedule, task_pool, finished
 
     def _process_current_schedule(self, schedule, allocation_pairs,
                                   workflow_id):

--- a/topsim/core/simulation.py
+++ b/topsim/core/simulation.py
@@ -95,7 +95,7 @@ class Simulation:
     Standard simulation with data frame output
 
     >>> env = simpy.environment()
-    >>> config = Config('path/to/config')
+    >>> config = Path('path/to/config')
     >>> instrument = CustomInstrument()
     >>> plan = PlanningModel()
     >>> sched = SchedulingModel()

--- a/topsim/user/plan/batch_planning.py
+++ b/topsim/user/plan/batch_planning.py
@@ -71,8 +71,9 @@ class BatchPlanning(Planning):
                         x, observation, clock
                     ) for x in pred
                 ]
-                edge_costs = {}
+
                 # Get the data transfer costs
+                edge_costs = {}
                 data = dict(graph.pred[task])
                 for element in data:
                     nm = self._create_observation_task_id(
@@ -80,10 +81,17 @@ class BatchPlanning(Planning):
                     )
                     val = data[element]["transfer_data"]
                     edge_costs[nm] = val
+
+                est, eft = 0, 0
+                machine_id = None
+                task_compute =  graph.nodes[task]['comp']
+                task_data = 0
+                if 'task_data' in  graph.nodes[task]:
+                    task_data = graph.nodes[task]['task_data']
+
                 taskobj = Task(
-                    tid, 0, 0, None, predecessors, graph.nodes[task][
-                        'comp'], 0,
-                    edge_costs, dm, gid=task
+                    tid, est, eft, machine_id, predecessors, task_compute,
+                    task_data, edge_costs, dm, gid=task
                 )
                 mapping[task] = taskobj
                 tasks.append(taskobj)

--- a/topsim/user/schedule/batch_allocation.py
+++ b/topsim/user/schedule/batch_allocation.py
@@ -131,7 +131,7 @@ class BatchProcessing(Scheduling):
             workflow_plan.status = WorkflowStatus.FINISHED
             logger.debug(f'{workflow_plan.id} is finished.')
             cluster.release_batch_resources(workflow_plan.id)
-        return allocations, workflow_plan.status
+        return allocations, workflow_plan.status, task_pool
 
     def to_df(self):
         pass

--- a/topsim/user/schedule/dynamic_plan.py
+++ b/topsim/user/schedule/dynamic_plan.py
@@ -61,48 +61,71 @@ class DynamicSchedulingFromPlan(Scheduling):
         replace = False
         allocations = copy.copy(existing_schedule)
         # allocations = copy.copy(existing_schedule)
+        if not task_pool:
+            for task in workflow_plan.tasks:
+                if not list(workflow_plan.graph.predecessors(task)):
+                    task_pool.add(task)
+        removed = set()
+        added = set()
         self.accurate = 0
         self.alternate = 0
-        for task in tasks:
-            if task not in allocations:
-                if (task.task_status is TaskStatus.UNSCHEDULED and
-                        task not in allocations):
-                    # Are we workflow - delayed?
-                    if workflow_plan.ast > workflow_plan.est:
-                        workflow_plan.status = WorkflowStatus.DELAYED
-                    if not task.pred:
-                        # TODO Reconsider using this method in the scheduling
-                        # We should just use it in the Scheduler
-                        machine = cluster.get_machine_from_id(
-                            task.allocated_machine_id
-                        )
-                        workflow_plan.status = WorkflowStatus.SCHEDULED
-                        # We do not update the allocations
-                        allocations[task] = machine  
+        temporary_resources = cluster.get_available_resources()
+        max_allocations_iteration = len(temporary_resources)
+        for task in sorted(task_pool, key=lambda x:x.est):
+            if len(allocations) >= max_allocations_iteration:
+                break
+            if (task.task_status is TaskStatus.UNSCHEDULED and
+                    task not in allocations and len(temporary_resources) > 0):
+                # Are we workflow - delayed?
+                if workflow_plan.ast > workflow_plan.est:
+                    workflow_plan.status = WorkflowStatus.DELAYED
+                # Task has no predecssors
+                machine = cluster.get_machine_from_id(task.allocated_machine_id)
+                if machine not in temporary_resources:
+                    continue
+                if not list(workflow_plan.graph.predecessors(task)): # if not task.pred:
+                    # TODO Reconsider using this method in the scheduling
+                    # We should just use it in the Scheduler
+                    workflow_plan.status = WorkflowStatus.SCHEDULED
+                    # We do not update the allocations
+                    allocations[task] = machine
+                    self.accurate += 1
+                    temporary_resources.remove(machine)
+                    removed.add(task)
+                    added.update(workflow_plan.graph.successors(task))
+                # The task has predecessors
+                else:
+                    # If the set of finished tasks does not contain all
+                    # of the previous tasks, we cannot start yet.
+                    pred = list(workflow_plan.graph.predecessors(task)) # set(task.pred)
+                    count = 0
+                    for p in pred:
+                        if cluster.is_task_finished(p):
+                            count += 1
+                    if count < len(pred):
+                        # One of the predecessors of 't' is still running
+                        continue
+                    # machine = cluster.get_machine_from_id(
+                    #     task.allocated_machine_id
+                    # )
+                    # finished = set(t.id for t in cluster.finished_tasks)
+                    # # Check if there is an overlap between the two sets
+                    # if not pred.issubset(finished):
+                    #     # One of the predecessors of 't' is still running
+                    #     continue
+                    else:
+                        allocations[task] = machine
+                        temporary_resources.remove(machine)
+                        removed.add(task)
+                        added.update((workflow_plan.graph.successors(task)))
                         self.accurate += 1
 
-                    # The task has predecessors
-                    else:
-                        # If the set of finished tasks does not contain all
-                        # of the previous tasks, we cannot start yet.
-                        pred = set(task.pred)
-                        machine = cluster.get_machine_from_id(
-                            task.allocated_machine_id
-                        )
-                        finished = set(t.id for t in cluster.finished_tasks)
-                        # Check if there is an overlap between the two sets
-                        if not pred.issubset(finished):
-                            # One of the predecessors of 't' is still running
-                            continue
-                        else:
-                            allocations[task] = machine
-                            self.accurate += 1
-
+        task_pool -= removed
+        task_pool.update(added)
         if len(workflow_plan.tasks) == 0:
             workflow_plan.status = WorkflowStatus.FINISHED
             logger.debug("is finished %s", workflow_id)
-
-        return allocations, workflow_plan.status
+        return allocations, workflow_plan.status, task_pool
 
     def to_df(self):
         df = pd.DataFrame()

--- a/topsim/user/schedule/greedy.py
+++ b/topsim/user/schedule/greedy.py
@@ -112,7 +112,7 @@ class GreedySchedulingFromPlan(Scheduling):
             workflow_plan.status = WorkflowStatus.FINISHED
             LOGGER.debug("is finished %s", workflow_id)
 
-        return allocations, workflow_plan.status
+        return allocations, workflow_plan.status, task_pool
 
     def to_df(self):
         """


### PR DESCRIPTION
This allows us to use task_data as a way of calculating runtime. If a workflow task has task_data, the duration the task is running on a compute node is the maximum of either the compute or IO runtime. 

I've added tests based on the HEFT graph to verify the behaviour. 