### PR TITLE
Update Buffer decision model

### DIFF
--- a/test/test_planner.py
+++ b/test/test_planner.py
@@ -51,7 +51,7 @@ class TestPlannerConfig(unittest.TestCase):
         config = Config(CONFIG)
         self.model = SHADOWPlanning('heft')
         self.cluster = Cluster(env=self.env, config=config)
-        self.buffer = Buffer(env=self.env, cluster=self.cluster, config=config)
+        # self.buffer = Buffer(env=self.env, cluster=self.cluster, config=config)
 
     def testPlannerBasicConfig(self):
         planner = Planner(
@@ -76,10 +76,10 @@ class TestWorkflowPlan(unittest.TestCase):
         config = Config(CONFIG)
         self.model = SHADOWPlanning('heft')
         self.cluster = Cluster(self.env, config=config)
-        self.buffer = Buffer(env=self.env, cluster=self.cluster, config=config)
         self.planner = Planner(
             self.env, self.cluster, self.model,
         )
+        self.buffer = Buffer(env=self.env, cluster=self.cluster, planner=self.planner, config=config)
         self.observation = Observation(
             'planner_observation',
             OBS_START_TME,
@@ -140,9 +140,9 @@ class TestPlannerDelay(unittest.TestCase):
         dm = DelayModel(0.1, "normal")
         self.model = SHADOWPlanning('heft', dm)
         self.cluster = Cluster(self.env, config=config)
-        self.buffer = Buffer(self.env, self.cluster, config)
         self.planner = Planner(self.env, self.cluster,
                                self.model, delay_model=dm)
+        self.buffer = Buffer(self.env, self.cluster, self.planner, config)
         self.observation = Observation(
             'planner_observation',
             OBS_START_TME,
@@ -193,10 +193,10 @@ class TestBatchProcessingPlan(unittest.TestCase):
         self.model = BatchPlanning('batch')
 
         self.cluster = Cluster(self.env, config=config)
-        self.buffer = Buffer(env=self.env, cluster=self.cluster, config=config)
         self.planner = Planner(
             self.env, self.cluster, self.model,
         )
+        self.buffer = Buffer(env=self.env, cluster=self.cluster, planner=self.planner, config=config)
         self.telescope = Telescope(
             self.env, config, planner=None, scheduler=None
         )

--- a/test/test_scheduling.py
+++ b/test/test_scheduling.py
@@ -58,15 +58,15 @@ class TestBatchSchedulerAllocation(unittest.TestCase):
         self.env = simpy.Environment()
         config = Config(CONFIG)
         self.cluster = Cluster(self.env, config=config)
-        self.buffer = Buffer(self.env, self.cluster, config)
-        self.scheduler = Scheduler(
-            self.env, self.buffer, self.cluster, DynamicSchedulingFromPlan()
-        )
-        self.algorithm = BatchProcessing()
         self.model = BatchPlanning('batch')
         self.planner = Planner(
             self.env, self.cluster, self.model,
         )
+        self.buffer = Buffer(self.env, self.cluster, self.planner, config)
+        self.scheduler = Scheduler(
+            self.env, self.buffer, self.cluster, DynamicSchedulingFromPlan()
+        )
+        self.algorithm = BatchProcessing()
 
         self.telescope = Telescope(
             self.env, config, self.planner, self.scheduler

--- a/test/test_simulation_data_output.py
+++ b/test/test_simulation_data_output.py
@@ -106,7 +106,7 @@ class TestMonitorPandasPickle(unittest.TestCase):
         heft_sim = pd.read_hdf(
             'test/simulation_data/test_hdf5.h5', key=heft_key
         )
-        self.assertEqual(118, len(heft_sim))
+        self.assertEqual(108, len(heft_sim))
         self.assertEqual(3, heft_sim.iloc[-1]['available_resources'])
 
 
@@ -135,7 +135,7 @@ class TestMonitorNoFileOption(unittest.TestCase):
             timestamp=None,
         )
         simdf, taskdf = simulation.start()
-        self.assertEqual(118, len(simdf))
+        self.assertEqual(108, len(simdf))
         self.env = simpy.Environment()
         simulation = Simulation(
             self.env,
@@ -149,7 +149,7 @@ class TestMonitorNoFileOption(unittest.TestCase):
             # delimiters=f'test/{algorithm}'
         )
         simdf, taskdf = simulation.start()
-        self.assertEqual(132, len(simdf))
+        self.assertEqual(122, len(simdf))
 
 
     def testResultsAgreeWithExpectations(self):

--- a/topsim/algorithms/planning.py
+++ b/topsim/algorithms/planning.py
@@ -84,7 +84,7 @@ class Planning(ABC):
         storage = buffer.buffer_storage_summary()
         size = observation.duration * observation.ingest_data_rate
         hot_to_cold_time = int(size/storage['coldbuffer']['data_rate'])
-        est = observation.duration + hot_to_cold_time
+        est = observation.duration # + hot_to_cold_time
         return est
 
     def _create_observation_task_id(self, tid, observation, clock):

--- a/topsim/core/simulation.py
+++ b/topsim/core/simulation.py
@@ -163,7 +163,6 @@ class Simulation:
         #: :py:obj:`~topsim.core.cluster.Cluster` instance
         self.cluster = Cluster(env, self._cfg)
         #: :py:obj:`~topsim.core.buffer.Buffer` instance
-        self.buffer = Buffer(env, self.cluster, self._cfg)
         planning_algorithm = None
         planning_model = planning_model
 
@@ -174,6 +173,7 @@ class Simulation:
         self.planner = Planner(
             env, self.cluster, planning_model, delay
         )
+        self.buffer = Buffer(env, self.cluster, self.planner, self._cfg)
         scheduling_algorithm = scheduling
         #: :py:obj:`~topsim.core.scheduler.Scheduler` instance
         self.scheduler = Scheduler(


### PR DESCRIPTION
- Buffer now requires the observation to be in the HotBuffer in order to be 'processed', rather than the HotBuffer
- This requires us to check if the HotBuffer is over a 'threshold' capacity, to trigger moving data to the cold buffer.
- Data must be moved from the cold-buffer back to the HotBuffer in order to be processed.