### PR TITLE
#18: Minimal JSON `"cluster"` option

### DIFF
--- a/test/basic-workflow-data/basic_simulation.json
+++ b/test/basic-workflow-data/basic_simulation.json
@@ -1,78 +1,79 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 2,
-			"pipelines": {
-				"first": {
-					"workflow": "workflows/basic_workflow_config.json",
-					"ingest_demand": 1
-				},
-				"second": {
-					"workflow": "workflows/basic_workflow_config.json",
-					"ingest_demand": 1
-				},
-				"third": {
-					"workflow": "workflows/basic_workflow_config.json",
-					"ingest_demand": 1
-				}
-			},
-			"observations": [
-				{
-					"name": "first",
-					"start": 0,
-					"duration": 1,
-					"instrument_demand": 36,
-					"data_product_rate": 5
-				},
-				{
-					"name": "second",
-					"start": 1,
-					"duration": 1,
-					"instrument_demand": 36,
-					"data_product_rate": 5
-				},
-				{
-					"name": "third",
-					"start": 2,
-					"duration": 1,
-					"instrument_demand": 36,
-					"data_product_rate": 5
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-			"time": "false",
-			"gen_specs": {
-			}
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 1.0,
-					"compute_bandwidth": 1.0
-				},
-				"cat1_m1": {
-					"flops": 2.0,
-					"compute_bandwidth": 1.0
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 10,
-			"max_ingest_rate": 5
-		},
-		"cold": {
-			"capacity": 10,
-			"max_data_rate": 5
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo",
-	"timestep": "seconds"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 2,
+      "pipelines": {
+        "first": {
+          "workflow": "workflows/basic_workflow_config.json",
+          "ingest_demand": 1
+        },
+        "second": {
+          "workflow": "workflows/basic_workflow_config.json",
+          "ingest_demand": 1
+        },
+        "third": {
+          "workflow": "workflows/basic_workflow_config.json",
+          "ingest_demand": 1
+        }
+      },
+      "observations": [
+        {
+          "name": "first",
+          "start": 0,
+          "duration": 1,
+          "instrument_demand": 36,
+          "data_product_rate": 5
+        },
+        {
+          "name": "second",
+          "start": 1,
+          "duration": 1,
+          "instrument_demand": 36,
+          "data_product_rate": 5
+        },
+        {
+          "name": "third",
+          "start": 2,
+          "duration": 1,
+          "instrument_demand": 36,
+          "data_product_rate": 5
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {
+      "time": "false",
+      "gen_specs": {}
+    },
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 1.0,
+          "flops": 1.0,
+          "count": 1
+        },
+        "cat1": {
+          "compute_bandwidth": 1.0,
+          "flops": 2.0,
+          "count": 1
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 10,
+      "max_ingest_rate": 5
+    },
+    "cold": {
+      "capacity": 10,
+      "max_data_rate": 5
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo",
+  "timestep": "seconds"
 }

--- a/test/data/config/deprecated_config/deprecated_heterogeneous_config.json
+++ b/test/data/config/deprecated_config/deprecated_heterogeneous_config.json
@@ -1,0 +1,57 @@
+{
+	"instrument": {
+		"telescope": {
+			"total_arrays": 36,
+			"max_ingest_resources": 1,
+			"pipelines": {
+				"emu": {
+					"workflow": "longtask/workflow_config_minutes_longtask.json",
+					"ingest_demand": 1
+				}
+			},
+			"observations": [
+				{
+					"name": "emu",
+					"start": 0,
+					"duration": 600,
+					"instrument_demand": 36,
+					"data_product_rate": 0.03333333333333333
+				}
+			]
+		}
+	},
+	"cluster": {
+		"header": {
+		},
+		"system": {
+			"resources": {
+				"cat0_m0": {
+					"flops": 7000.0,
+					"compute_bandwidth": 1.0
+				},
+				"cat1_m1": {
+					"flops": 6000.0,
+					"compute_bandwidth": 1.0
+				},
+				"cat2_m2": {
+					"flops": 11000.0,
+					"compute_bandwidth": 1.0
+				}
+			},
+			"system_bandwidth": 1.0
+		}
+	},
+	"buffer": {
+		"hot": {
+			"capacity": 500,
+			"max_ingest_rate": 0.08333333333333333
+		},
+		"cold": {
+			"capacity": 250,
+			"max_data_rate": 0.03333333333333333
+		}
+	},
+	"planning": "heft",
+	"scheduling": "fifo",
+	"timestep": "minutes"
+}

--- a/test/data/config/deprecated_config/deprecated_homogeneous_config.json
+++ b/test/data/config/deprecated_config/deprecated_homogeneous_config.json
@@ -1,0 +1,104 @@
+{
+	"instrument": {
+		"telescope": {
+			"total_arrays": 36,
+			"max_ingest_resources": 5,
+			"pipelines": {
+				"emu":
+				{
+					"workflow": "integration/workflow_config_heft_sim.json",
+					"ingest_demand": 5
+				},
+				"dingo": {
+					"workflow": "integration/workflow_config_heft_sim.json",
+					"ingest_demand": 10
+				}
+			},
+		"observations": [
+			{
+				"name": "emu",
+				"start": 1,
+				"duration": 10,
+				"instrument_demand": 36,
+				"data_product_rate": 4000000000.0
+			},
+			{
+				"name": "dingo",
+				"start": 15,
+				"duration": 20,
+				"instrument_demand": 18,
+				"data_product_rate": 5000000000.0
+			}
+		]
+		}
+	},
+	"cluster": {
+		"header": {
+			"time": "false",
+			"gen_specs": {
+				"file": "recipes/routput/basic_spec-10.json",
+				"seed": 20,
+				"range": "[(50, 100)]",
+				"heterogeneity": 1.0,
+				"multiplier": 1
+			}
+		},
+		"system": {
+			"resources": {
+				"cat0_m0": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m1": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m2": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m3": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m4": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m5": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m6": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m7": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m8": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				},
+				"cat0_m9": {
+					"flops": 84,
+					"compute_bandwidth": 10
+				}
+			},
+			"system_bandwidth": 1.0
+		}
+	},
+	"buffer": {
+		"hot": {
+			"capacity": 500000000000.0,
+			"max_ingest_rate": 5000000000.0
+		},
+		"cold": {
+			"capacity": 250000000000.0,
+			"max_data_rate": 2000000000.0
+		}
+	},
+	"planning": "heft",
+	"scheduling": "fifo"
+}

--- a/test/data/config/heft_single_observation_simulation.json
+++ b/test/data/config/heft_single_observation_simulation.json
@@ -1,57 +1,59 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 1,
-			"pipelines": {
-				"emu": {
-					"workflow": "longtask/workflow_config_minutes_longtask.json",
-					"ingest_demand": 1
-				}
-			},
-			"observations": [
-				{
-					"name": "emu",
-					"start": 0,
-					"duration": 600,
-					"instrument_demand": 36,
-					"data_product_rate": 0.03333333333333333
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 7000.0,
-					"compute_bandwidth": 1.0
-				},
-				"cat1_m1": {
-					"flops": 6000.0,
-					"compute_bandwidth": 1.0
-				},
-				"cat2_m2": {
-					"flops": 11000.0,
-					"compute_bandwidth": 1.0
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 500,
-			"max_ingest_rate": 0.08333333333333333
-		},
-		"cold": {
-			"capacity": 250,
-			"max_data_rate": 0.03333333333333333
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo",
-	"timestep": "minutes"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 1,
+      "pipelines": {
+        "emu": {
+          "workflow": "longtask/workflow_config_minutes_longtask.json",
+          "ingest_demand": 1
+        }
+      },
+      "observations": [
+        {
+          "name": "emu",
+          "start": 0,
+          "duration": 600,
+          "instrument_demand": 36,
+          "data_product_rate": 0.03333333333333333
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {},
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 1.0,
+          "flops": 7000.0,
+          "count": 1
+        },
+        "cat1": {
+          "compute_bandwidth": 1.0,
+          "flops": 6000.0,
+          "count": 1
+        },
+        "cat2": {
+          "compute_bandwidth": 1.0,
+          "flops": 11000.0,
+          "count": 1
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 500,
+      "max_ingest_rate": 0.08333333333333333
+    },
+    "cold": {
+      "capacity": 250,
+      "max_data_rate": 0.03333333333333333
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo",
+  "timestep": "minutes"
 }

--- a/test/data/config/heft_single_observation_simulation_IO.json
+++ b/test/data/config/heft_single_observation_simulation_IO.json
@@ -1,57 +1,59 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 1,
-			"pipelines": {
-				"emu": {
-					"workflow": "longtask/workflow_config_minutes_longtask_IO.json",
-					"ingest_demand": 1
-				}
-			},
-			"observations": [
-				{
-					"name": "emu",
-					"start": 0,
-					"duration": 600,
-					"instrument_demand": 36,
-					"data_product_rate": 0.03333333333333333
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 1.0,
-					"compute_bandwidth": 7000.0
-				},
-				"cat1_m1": {
-					"flops": 1.0,
-					"compute_bandwidth": 6000.0
-				},
-				"cat2_m2": {
-					"flops": 1.0,
-					"compute_bandwidth": 11000.0
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 500,
-			"max_ingest_rate": 0.08333333333333333
-		},
-		"cold": {
-			"capacity": 250,
-			"max_data_rate": 0.03333333333333333
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo",
-	"timestep": "minutes"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 1,
+      "pipelines": {
+        "emu": {
+          "workflow": "longtask/workflow_config_minutes_longtask_IO.json",
+          "ingest_demand": 1
+        }
+      },
+      "observations": [
+        {
+          "name": "emu",
+          "start": 0,
+          "duration": 600,
+          "instrument_demand": 36,
+          "data_product_rate": 0.03333333333333333
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {},
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 7000.0,
+          "flops": 1.0,
+          "count": 1
+        },
+        "cat1": {
+          "compute_bandwidth": 6000.0,
+          "flops": 1.0,
+          "count": 1
+        },
+        "cat2": {
+          "compute_bandwidth": 11000.0,
+          "flops": 1.0,
+          "count": 1
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 500,
+      "max_ingest_rate": 0.08333333333333333
+    },
+    "cold": {
+      "capacity": 250,
+      "max_data_rate": 0.03333333333333333
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo",
+  "timestep": "minutes"
 }

--- a/test/data/config/integration_simulation.json
+++ b/test/data/config/integration_simulation.json
@@ -1,104 +1,68 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 5,
-			"pipelines": {
-				"emu":
-				{
-					"workflow": "integration/workflow_config_heft_sim.json",
-					"ingest_demand": 5
-				},
-				"dingo": {
-					"workflow": "integration/workflow_config_heft_sim.json",
-					"ingest_demand": 10
-				}
-			},
-		"observations": [
-			{
-				"name": "emu",
-				"start": 1,
-				"duration": 10,
-				"instrument_demand": 36,
-				"data_product_rate": 4000000000.0
-			},
-			{
-				"name": "dingo",
-				"start": 15,
-				"duration": 20,
-				"instrument_demand": 18,
-				"data_product_rate": 5000000000.0
-			}
-		]
-		}
-	},
-	"cluster": {
-		"header": {
-			"time": "false",
-			"gen_specs": {
-				"file": "recipes/routput/basic_spec-10.json",
-				"seed": 20,
-				"range": "[(50, 100)]",
-				"heterogeneity": 1.0,
-				"multiplier": 1
-			}
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m1": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m2": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m3": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m4": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m5": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m6": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m7": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m8": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m9": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 500000000000.0,
-			"max_ingest_rate": 5000000000.0
-		},
-		"cold": {
-			"capacity": 250000000000.0,
-			"max_data_rate": 2000000000.0
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 5,
+      "pipelines": {
+        "emu": {
+          "workflow": "integration/workflow_config_heft_sim.json",
+          "ingest_demand": 5
+        },
+        "dingo": {
+          "workflow": "integration/workflow_config_heft_sim.json",
+          "ingest_demand": 10
+        }
+      },
+      "observations": [
+        {
+          "name": "emu",
+          "start": 1,
+          "duration": 10,
+          "instrument_demand": 36,
+          "data_product_rate": 4000000000.0
+        },
+        {
+          "name": "dingo",
+          "start": 15,
+          "duration": 20,
+          "instrument_demand": 18,
+          "data_product_rate": 5000000000.0
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {
+      "time": "false",
+      "gen_specs": {
+        "file": "recipes/routput/basic_spec-10.json",
+        "seed": 20,
+        "range": "[(50, 100)]",
+        "heterogeneity": 1.0,
+        "multiplier": 1
+      }
+    },
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 10,
+          "flops": 84,
+          "count": 10
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 500000000000.0,
+      "max_ingest_rate": 5000000000.0
+    },
+    "cold": {
+      "capacity": 250000000000.0,
+      "max_data_rate": 2000000000.0
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo"
 }

--- a/test/data/config/mos_sw10_long.json
+++ b/test/data/config/mos_sw10_long.json
@@ -1,213 +1,57 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 5,
-			"pipelines": {
-				"dingo": {
-					"workflow": "longconfig/shadow_Continuum_ChannelSplit_10_long.json",
-					"ingest_demand": 5
-				}
-			},
-			"observations": [
-				{
-					"name": "dingo",
-					"start": 0,
-					"duration": 150,
-					"instrument_demand": 36,
-					"data_product_rate": 5
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-			"time": "false",
-			"gen_specs": {
-				"file": "system_spec_40_200-400_1.0",
-				"seed": 20,
-				"range": "[(200, 400)]",
-				"heterogeneity": 1.0,
-				"multiplier": 1
-			}
-		},
-		"system": {
-			"resources": {
-					"cat0_m0": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m1": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m2": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m3": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m4": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m5": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m6": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m7": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m8": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m9": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m10": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m11": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m12": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m13": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m14": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m15": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m16": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m17": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m18": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m19": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m20": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m21": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m22": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m23": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m24": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m25": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m26": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m27": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m28": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m29": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m30": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m31": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m32": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m33": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m34": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m35": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m36": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m37": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m38": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					},
-					"cat0_m39": {
-						"flops": 35000,
-						"compute_bandwidth": 10
-					}
-
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 2000,
-			"max_ingest_rate": 5
-		},
-		"cold": {
-			"capacity": 5000,
-			"max_data_rate": 5
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 5,
+      "pipelines": {
+        "dingo": {
+          "workflow": "longconfig/shadow_Continuum_ChannelSplit_10_long.json",
+          "ingest_demand": 5
+        }
+      },
+      "observations": [
+        {
+          "name": "dingo",
+          "start": 0,
+          "duration": 150,
+          "instrument_demand": 36,
+          "data_product_rate": 5
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {
+      "time": "false",
+      "gen_specs": {
+        "file": "system_spec_40_200-400_1.0",
+        "seed": 20,
+        "range": "[(200, 400)]",
+        "heterogeneity": 1.0,
+        "multiplier": 1
+      }
+    },
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 10,
+          "flops": 35000,
+          "count": 40
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 2000,
+      "max_ingest_rate": 5
+    },
+    "cold": {
+      "capacity": 5000,
+      "max_data_rate": 5
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo"
 }

--- a/test/data/config/standard_simulation.json
+++ b/test/data/config/standard_simulation.json
@@ -1,99 +1,63 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 5,
-			"pipelines": {
-				"emu": {
-					"workflow": "standard/workflow_config_minutes.json",
-					"ingest_demand": 5
-				},
-				"dingo": {
-					"workflow": "standard/workflow_config_minutes.json",
-					"ingest_demand": 5
-				}
-			},
-			"observations": [
-				{
-					"name": "emu",
-					"start": 0,
-					"duration": 600,
-					"instrument_demand": 36,
-					"data_product_rate": 66666666.6666666
-				},
-				{
-					"name": "dingo",
-					"start": 900,
-					"duration": 1200,
-					"instrument_demand": 18,
-					"data_product_rate": 83333333.3333334
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-			"time": "false",
-			"gen_specs": {
-			}
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m1": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m2": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m3": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m4": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m5": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m6": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m7": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m8": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m9": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 500000000000.0,
-			"max_ingest_rate": 83333333.33333333
-		},
-		"cold": {
-			"capacity": 250000000000.0,
-			"max_data_rate": 33333333.333333333
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo",
-	"timestep": "minutes"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 5,
+      "pipelines": {
+        "emu": {
+          "workflow": "standard/workflow_config_minutes.json",
+          "ingest_demand": 5
+        },
+        "dingo": {
+          "workflow": "standard/workflow_config_minutes.json",
+          "ingest_demand": 5
+        }
+      },
+      "observations": [
+        {
+          "name": "emu",
+          "start": 0,
+          "duration": 600,
+          "instrument_demand": 36,
+          "data_product_rate": 66666666.6666666
+        },
+        {
+          "name": "dingo",
+          "start": 900,
+          "duration": 1200,
+          "instrument_demand": 18,
+          "data_product_rate": 83333333.3333334
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {
+      "time": "false",
+      "gen_specs": {}
+    },
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 10,
+          "flops": 84,
+          "count": 10
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 500000000000.0,
+      "max_ingest_rate": 83333333.33333333
+    },
+    "cold": {
+      "capacity": 250000000000.0,
+      "max_data_rate": 33333333.333333332
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo",
+  "timestep": "minutes"
 }

--- a/test/data/config/standard_simulation_longtask.json
+++ b/test/data/config/standard_simulation_longtask.json
@@ -1,99 +1,63 @@
 {
-	"instrument": {
-		"telescope": {
-			"total_arrays": 36,
-			"max_ingest_resources": 5,
-			"pipelines": {
-				"emu": {
-					"workflow": "longtask/workflow_config_minutes_longtask.json",
-					"ingest_demand": 5
-				},
-				"dingo": {
-					"workflow": "longtask/workflow_config_minutes_longtask.json",
-					"ingest_demand": 5
-				}
-			},
-			"observations": [
-				{
-					"name": "emu",
-					"start": 0,
-					"duration": 600,
-					"instrument_demand": 36,
-					"data_product_rate": 66666666.66666666
-				},
-				{
-					"name": "dingo",
-					"start": 900,
-					"duration": 1200,
-					"instrument_demand": 18,
-					"data_product_rate": 83333333.33333
-				}
-			]
-		}
-	},
-	"cluster": {
-		"header": {
-			"time": "false",
-			"gen_specs": {
-			}
-		},
-		"system": {
-			"resources": {
-				"cat0_m0": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m1": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m2": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m3": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m4": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m5": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m6": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m7": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m8": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				},
-				"cat0_m9": {
-					"flops": 84,
-					"compute_bandwidth": 10
-				}
-			},
-			"system_bandwidth": 1.0
-		}
-	},
-	"buffer": {
-		"hot": {
-			"capacity": 500000000000.0,
-			"max_ingest_rate": 83333333.33333333
-		},
-		"cold": {
-			"capacity": 250000000000.0,
-			"max_data_rate": 33333333.333333333
-		}
-	},
-	"planning": "heft",
-	"scheduling": "fifo",
-	"timestep": "minutes"
+  "instrument": {
+    "telescope": {
+      "total_arrays": 36,
+      "max_ingest_resources": 5,
+      "pipelines": {
+        "emu": {
+          "workflow": "longtask/workflow_config_minutes_longtask.json",
+          "ingest_demand": 5
+        },
+        "dingo": {
+          "workflow": "longtask/workflow_config_minutes_longtask.json",
+          "ingest_demand": 5
+        }
+      },
+      "observations": [
+        {
+          "name": "emu",
+          "start": 0,
+          "duration": 600,
+          "instrument_demand": 36,
+          "data_product_rate": 66666666.66666666
+        },
+        {
+          "name": "dingo",
+          "start": 900,
+          "duration": 1200,
+          "instrument_demand": 18,
+          "data_product_rate": 83333333.33333
+        }
+      ]
+    }
+  },
+  "cluster": {
+    "header": {
+      "time": "false",
+      "gen_specs": {}
+    },
+    "system": {
+      "resources": {
+        "cat0": {
+          "compute_bandwidth": 10,
+          "flops": 84,
+          "count": 10
+        }
+      },
+      "system_bandwidth": 1.0
+    }
+  },
+  "buffer": {
+    "hot": {
+      "capacity": 500000000000.0,
+      "max_ingest_rate": 83333333.33333333
+    },
+    "cold": {
+      "capacity": 250000000000.0,
+      "max_data_rate": 33333333.333333332
+    }
+  },
+  "planning": "heft",
+  "scheduling": "fifo",
+  "timestep": "minutes"
 }

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -71,10 +71,10 @@ class TestClusterConfig(unittest.TestCase):
 
     def testReplaceOldConfigHetergeneous(self):
         """
+        Confirm that heterogeneous machine specs are accurately separated.
 
-        Returns
-        -------
-
+        For the example path, we would expect to go from 3 machine entries to
+        3 machine entries, as there are 3 different machines in the config.
         """
         tmp = Path(OLD_CONFIG_HETEROGENEOUS)
         self.cfg_path = tmp.parent.joinpath("tmp.json")
@@ -89,9 +89,11 @@ class TestClusterConfig(unittest.TestCase):
 
     def testReplaceOldConfigHomogeneous(self):
         """
+        Confirm that heterogeneous machine specs are accurately separated.
 
-        Returns
-        -------
+        For the example path, we would expect to go from 10 machine entries to
+        1 machine entry in the JSON, as there is only one machine type in the config.
+
 
         """
         tmp = Path(OLD_CONFIG_HOMOGENEOUS)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -16,10 +16,13 @@
 """
 Unit tests for the Config class. Test configuration for all
 """
-
+import shutil
 import unittest
 import json
 
+from pathlib import Path
+
+from scipy.linalg import bandwidth
 from topsim.core.config import Config
 from topsim.user.telescope import Telescope
 
@@ -30,6 +33,8 @@ NOT_JSON = "test/data/config/NotJSONFileTest.txt"
 MISSING_KEYS = "test/data/config/config_missing_keys.json"
 CONFIG_CUSTOM_TIMESTEP = "test/data/config/custom_timestep.json"
 
+OLD_CONFIG_HETEROGENEOUS = "test/data/config/deprecated_config/deprecated_heterogeneous_config.json"
+OLD_CONFIG_HOMOGENEOUS = "test/data/config/deprecated_config/deprecated_homogeneous_config.json"
 
 class TestGeneralConfig(unittest.TestCase):
 
@@ -60,6 +65,45 @@ class TestActorConfigIncorrectJSON(unittest.TestCase):
 
     def test_buffer_config_incorrect_json(self):
         self.assertRaises(KeyError, self.config.parse_buffer_config)
+
+
+class TestClusterConfig(unittest.TestCase):
+
+    def testReplaceOldConfigHetergeneous(self):
+        """
+
+        Returns
+        -------
+
+        """
+        tmp = Path(OLD_CONFIG_HETEROGENEOUS)
+        self.cfg_path = tmp.parent.joinpath("tmp.json")
+        shutil.copy(tmp, self.cfg_path)
+        config = Config(str(self.cfg_path))
+        machine_list, bandwidth = config.parse_cluster_config()
+        self.assertEqual(3, len(machine_list))
+        with open(self.cfg_path) as fp:
+            dict = json.load(fp)
+            self.assertEqual(3, len(dict["cluster"]["system"]["resources"]))
+        self.cfg_path.unlink()
+
+    def testReplaceOldConfigHomogeneous(self):
+        """
+
+        Returns
+        -------
+
+        """
+        tmp = Path(OLD_CONFIG_HOMOGENEOUS)
+        self.cfg_path = tmp.parent.joinpath("tmp.json")
+        shutil.copy(tmp, self.cfg_path)
+        config = Config(str(self.cfg_path))
+        machine_list, bandwidth = config.parse_cluster_config()
+        self.assertEqual(10, len(machine_list))
+        with open(self.cfg_path) as fp:
+            dict = json.load(fp)
+            self.assertEqual(1, len(dict["cluster"]["system"]["resources"]))
+        self.cfg_path.unlink()
 
 
 class TestActorConfigurationReturnsCorrectDictionary(unittest.TestCase):

--- a/test/test_planner.py
+++ b/test/test_planner.py
@@ -72,9 +72,9 @@ class TestPlannerConfig(unittest.TestCase):
             self.cluster, self.observation)
         # Bandwidth set at 1gb/s = 60gb/min.
         self.assertEqual(60.0, available_resources['system']["system_bandwidth"])
-        machine = available_resources['system']['resources']['cat0_m0']
+        machine = available_resources['system']['resources']['cat0_0']
         self.assertEqual(
-            5040, available_resources['system']['resources']['cat0_m0']['flops']
+            5040, available_resources['system']['resources']['cat0_0']['flops']
         )
 
 

--- a/topsim/core/config.py
+++ b/topsim/core/config.py
@@ -15,6 +15,7 @@
 
 
 import json
+from collections import defaultdict
 from pathlib import Path
 from topsim.core.instrument import Observation
 from topsim.core.machine import Machine
@@ -86,6 +87,7 @@ class Config:
         else:
             self.timestep_unit = 'seconds'
 
+
     def parse_cluster_config(self):
         try:
             (self.cluster['system'] and self.cluster['system']['resources'] and
@@ -96,7 +98,6 @@ class Config:
                 self.cluster)
             raise
 
-        machines = self.cluster['system']['resources']
         machine_list = []
         timestep_multiplier = 1
         if self.timestep_unit == 'minutes':
@@ -109,16 +110,65 @@ class Config:
         else:  # Seconds
             timestep_multiplier = timestep_multiplier
 
-        for machine in machines:
-            cpu = machines[machine]['flops'] * timestep_multiplier
-            machine_list.append(
-                Machine(id=machine, cpu=cpu, memory=1,  # * timestep_multiplier,
-                        disk=1,  # * timestep_multiplier,
-                        bandwidth=machines[machine][
-                                      "compute_bandwidth"] * timestep_multiplier))
+        # Test
+        # name, spec = next(machines_types.items())
+        if not self._check_cluster():
+            self._update_config()
 
+        machines_types = self.cluster['system']['resources']
+        for name, spec in machines_types.items():
+            num_machines = spec.get("count")
+            for i in range(num_machines):
+                cpu = spec["flops"] * timestep_multiplier
+                machine_list.append(
+                    Machine(id=f"{name}_{i}", cpu=cpu,
+                            memory=1,  # * timestep_multiplier,
+                            disk=1,  # * timestep_multiplier,
+                            bandwidth=(machines_types[name]["compute_bandwidth"]
+                                       * timestep_multiplier)
+                            )
+                )
         bandwidth = self.cluster['system']["system_bandwidth"] * timestep_multiplier
         return machine_list, bandwidth
+
+    def _check_cluster(self):
+        """
+
+        """
+
+        machines_types = self.cluster['system']['resources']
+        example_key = list(machines_types.keys())[0]
+        return machines_types[example_key].get("count")
+
+
+    def _update_config(self):
+        """
+
+        :return:
+        """
+        resources = self.cluster["system"]["resources"]
+        grouped_specs = defaultdict(list)
+        for name, spec in resources.items():
+            # Use dictionary data as key to determine unique entries:
+            spec["name"] = name.split("_")[0]
+            spec_key = json.dumps(spec, sort_keys=True)
+            grouped_specs[spec_key].append(spec)
+
+        updated_resources = {}
+        for spec_string, spec_list in grouped_specs.items():
+            spec = json.loads(spec_string)
+            name = spec["name"]
+            del spec["name"]
+
+            spec["count"] = len(spec_list)
+            updated_resources[name] = spec
+        self.cluster["system"]["resources"] = updated_resources
+
+        with open(self.path, 'r') as fp:
+            dict = json.load(fp)
+        with open(self.path, 'w') as fp:
+            dict["cluster"]["system"]["resources"] = updated_resources
+            json.dump(dict, fp, indent=2)
 
     def parse_instrument_config(self, instrument_name):
         timestep_multiplier = 1
@@ -194,3 +244,42 @@ class Config:
     def get_max_ingest(self, instrument_name):
 
         return self.instrument[instrument_name]['max_ingest_resources']
+    
+    
+    
+    """
+    	"cluster": {
+		"header": {
+		},
+		"system": {
+			"resources": {
+				"cat0_m0": {
+					"flops": 1.0,
+					"compute_bandwidth": 7000.0
+				},
+				"cat1_m1": {
+					"flops": 1.0,
+					"compute_bandwidth": 6000.0
+				},
+				"cat2_m2": {
+					"flops": 1.0,
+					"compute_bandwidth": 11000.0
+				}
+			},
+			"system_bandwidth": 1.0
+		}
+	},
+
+    to: 
+    "system": {
+        "resources": {
+            "m0": {count: ...} 
+            "m1": {count: ...}
+            "m2": {count: ...}
+        }
+    """
+    def _process_cluster(self):
+
+        return machine_list
+
+

--- a/topsim/user/plan/batch_planning.py
+++ b/topsim/user/plan/batch_planning.py
@@ -124,7 +124,7 @@ class BatchPlanning(Planning):
         """
         with open(workflow, 'r') as infile:
             config = json.load(infile)
-        graph = nx.readwrite.node_link_graph(config['graph'])
+        graph = nx.readwrite.node_link_graph(config['graph'], edges="links")
         return graph
 
     def to_df(self):

--- a/topsim/user/schedule/batch_allocation.py
+++ b/topsim/user/schedule/batch_allocation.py
@@ -213,7 +213,7 @@ class BatchProcessing(Scheduling):
             if self.use_workflow_dop:
                 with open(observation.workflow, 'r') as infile:
                     wfconfig = json.load(infile)
-                graph = nx.readwrite.json_graph.node_link_graph(wfconfig['graph'])
+                graph = nx.readwrite.json_graph.node_link_graph(wfconfig['graph'], edges="links")
 
                 graph_dop = (max(graph.out_degree(list(graph.nodes)),
                              key=lambda x: x[1]))[1] / 2

--- a/topsim/user/schedule/dynamic_plan.py
+++ b/topsim/user/schedule/dynamic_plan.py
@@ -231,7 +231,7 @@ class DynamicSchedulingFromPlan(Scheduling):
             if self.use_workflow_dop:
                 with open(observation.workflow, 'r') as infile:
                     wfconfig = json.load(infile)
-                graph = nx.readwrite.json_graph.node_link_graph(wfconfig['graph'])
+                graph = nx.readwrite.json_graph.node_link_graph(wfconfig['graph'], edges="links")
 
                 graph_dop = (max(graph.out_degree(list(graph.nodes)),
                              key=lambda x: x[1]))[1] / 2


### PR DESCRIPTION
This PR address #18, which I've wanted to do for ages. 

We now only store one of each  "machine type" and store the number of them in the config file. This means the file is not full of duplicated entries. 

I have also added support to overwrite the existing configuration file if the "count" doesn't exist in it, thus automatically converting any existing configuration files to the new approach. 
- I have added unittests to test this over-writing approach. 