### PR TITLE
#40: Remove task data and simplify 'sim' dataframe

### DIFF
--- a/topsim/core/scheduler.py
+++ b/topsim/core/scheduler.py
@@ -275,7 +275,6 @@ class Scheduler:
         _tqdm = True
         pbar_setup = False
         pbar = None
-        self._add_event(observation, "allocation", "started")
         while True:
             if current_plan:
                 current_plan.tasks = self._update_current_plan(current_plan)
@@ -290,6 +289,9 @@ class Scheduler:
             if not current_plan:
                 yield self.env.timeout(TIMESTEP)
                 continue
+            else:
+                # We have a plan, which means we are no longer waiting around for resources
+                self._add_event(observation, "allocation", "started")
             if _tqdm and not pbar_setup:
                 _total_tasks = len(current_plan.tasks)
                 _curr_tasks = len(current_plan.tasks)
@@ -497,10 +499,6 @@ class Scheduler:
         df['scheduler_observation_queue'] = [int(len(self.observation_queue))]
         df['schedule_status'] = [str(self.schedule_status.value)]
         df['delay_offset'] = [self.delay_offset]
-        tmp = f'alg'
-        if self.algtime:
-            for key, value in self.algtime.items():
-                df[key] = value
         return df
 
     def to_summary(self):
@@ -509,8 +507,6 @@ class Scheduler:
         current timestep
 
         The scheduler has the following key events that can happen each timestep
-
-        *
 
         Returns
         -------

--- a/topsim/core/simulation.py
+++ b/topsim/core/simulation.py
@@ -272,9 +272,8 @@ class Simulation:
         if self.to_file and self._hdf5_store is not None:
             global_df = self.monitor.df
             summary_df = self.monitor.events
-            task_df = self._generate_final_task_data()
             self._hdf5_store.open()
-            self._compose_hdf5_output(global_df, task_df, summary_df)
+            self._compose_hdf5_output(global_df, summary_df)
             self._hdf5_store.close()
 
         else:
@@ -348,8 +347,6 @@ class Simulation:
         finish = max(events['timestep'],0)
 
 
-
-
     @staticmethod
     def _split_monolithic_config(self, json):
         return json
@@ -372,7 +369,7 @@ class Simulation:
         df['config'] = [str(self._cfg_path) for x in range(size)]
         return df.infer_objects()
 
-    def _compose_hdf5_output(self, global_df, tasks_df, summary_df):
+    def _compose_hdf5_output(self, global_df, summary_df):
         """
         Given a :py:obj:`pandas.HDFStore()` object, put global simulation,
         task specific, and configuration data into HDF5 storage files.
@@ -380,8 +377,8 @@ class Simulation:
         ----------
         global_df : :py:obj:pandas.DataFrame
             The global, per-timestep overview of the simulation
-        tasks_df : :py:obj:pandas.DataFrame
-            Information on each tasks' execution throughout the simulation.
+        summary_df : :py:obj:pandas.DataFrame
+            Information on the major events in each actor
         Returns
         -------
 
@@ -397,8 +394,6 @@ class Simulation:
         final_key = f'{ts}/{self._delimiters}/{sanitised_path}'
         global_df = global_df.fillna(0)
         self._hdf5_store.put(key=f"{final_key}/sim", value=global_df)
-        self._hdf5_store.put(key=f'{final_key}/tasks',
-                             value=tasks_df)
         self._hdf5_store.put(key=f'{final_key}/summary',
                              value=summary_df)
 


### PR DESCRIPTION
- Task data has never been used for generating results and it is enormous, so I think we can remove it without issue.
- The sim data frame also stored an individual algorithm runtime for each timestep, for each observation. This was also never used, and is a huge waste of dataframe colums/rows.

For the time being, we will remove both of these data hogs from the code and see if we ever need them back.